### PR TITLE
Disambiguate `Word` (compat for GHC 7.10/base-4.8)

### DIFF
--- a/Data/Text/ICU/Break.hsc
+++ b/Data/Text/ICU/Break.hsc
@@ -22,7 +22,7 @@ module Data.Text.ICU.Break
     -- * Types
       BreakIterator
     , Line(..)
-    , Word(..)
+    , Data.Text.ICU.Break.Word(..)
     -- * Breaking functions
     , breakCharacter
     , breakLine
@@ -95,7 +95,7 @@ data Word = Uncategorized       -- ^ A \"word\" that does not fit into another
           | Ideograph           -- ^ A word containing ideographic characters.
             deriving (Eq, Show, Enum)
 
-instance NFData Word where
+instance NFData Data.Text.ICU.Break.Word where
     rnf !_ = ()
 
 -- | Break a string on character boundaries.
@@ -138,7 +138,7 @@ breakSentence = open (#const UBRK_SENTENCE) (const ())
 -- punctuation marks within and following words. Characters that are not
 -- part of a word, such as symbols or punctuation marks, have word breaks on
 -- both sides.
-breakWord :: LocaleName -> Text -> IO (BreakIterator Word)
+breakWord :: LocaleName -> Text -> IO (BreakIterator Data.Text.ICU.Break.Word)
 breakWord = open (#const UBRK_WORD) asWord
   where
     asWord i

--- a/Data/Text/ICU/Break/Pure.hs
+++ b/Data/Text/ICU/Break/Pure.hs
@@ -27,7 +27,7 @@ module Data.Text.ICU.Break.Pure
     , brkSuffix
     , brkStatus
     , Line(..)
-    , Word(..)
+    , Data.Text.ICU.Break.Word(..)
     -- * Breaking functions
     , breakCharacter
     , breakLine
@@ -88,7 +88,7 @@ breakSentence = new IO.breakSentence
 -- punctuation marks within and following words. Characters that are not
 -- part of a word, such as symbols or punctuation marks, have word breaks on
 -- both sides.
-breakWord :: LocaleName -> Breaker Word
+breakWord :: LocaleName -> Breaker Data.Text.ICU.Break.Word
 breakWord = new IO.breakWord
 
 -- | A break in a string.


### PR DESCRIPTION
I avoided `CPP`-conditionals in this fix to simplify testing

With this fix, the code compiles w/ soon-to-be GHC 7.10 & base-4.8