### PR TITLE
Fix compiling with GHC 7.10 by hiding Prelude.Word.

### DIFF
--- a/Data/Text/ICU/Break.hsc
+++ b/Data/Text/ICU/Break.hsc
@@ -64,7 +64,7 @@ import Foreign.ForeignPtr (newForeignPtr, withForeignPtr)
 import Foreign.Marshal.Array (allocaArray, peekArray)
 import Foreign.Marshal.Utils (with)
 import Foreign.Ptr (FunPtr, Ptr, nullPtr)
-import Prelude hiding (last)
+import Prelude hiding (last, Word)
 import System.IO.Unsafe (unsafePerformIO)
 
 -- $indices

--- a/Data/Text/ICU/Break/Pure.hs
+++ b/Data/Text/ICU/Break/Pure.hs
@@ -44,6 +44,7 @@ import Data.Text.Foreign (dropWord16, takeWord16)
 import Data.Text.ICU.Break (Line, Word)
 import Data.Text.ICU.Break.Types (BreakIterator(..))
 import Data.Text.ICU.Internal (LocaleName)
+import Prelude hiding (Word)
 import System.IO.Unsafe (unsafeInterleaveIO, unsafePerformIO)
 import qualified Data.Text.ICU.Break as IO
 


### PR DESCRIPTION
Should I add some CPP to get rid of warnings on older GHC versions or is it fine as it is?