### PR TITLE
Some minor ICU API updates

### DIFF
--- a/Data/Text/ICU/Collate/Internal.hs
+++ b/Data/Text/ICU/Collate/Internal.hs
@@ -33,8 +33,7 @@ data UCollator
 data MCollator = MCollator {-# UNPACK #-} !(ForeignPtr UCollator)
                  deriving (Typeable)
 
--- | String collator type.  'Collator's are considered equal if they
--- will sort strings identically.
+-- | String collator type.
 newtype Collator = C MCollator
     deriving (Typeable)
 

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,8 @@ the following:
 
 This library is implemented as bindings to the well-respected [ICU
 library](http://www.icu-project.org/), which is not included.  The versions
-of ICU currently supported are 4.0 and newer.
+of ICU currently supported are 4.0 and newer;
+verified at least up to ICU version 55.
 
 
 # Get involved!

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -385,8 +385,8 @@ void __hs_uregex_close(URegularExpression *regexp)
     return uregex_close(regexp);
 }
 
-URegularExpression *__hs_uregex_clone(URegularExpression *regexp,
-				      UErrorCode *pErrorCode)
+URegularExpression * __hs_uregex_clone(const URegularExpression *regexp,
+				       UErrorCode *pErrorCode)
 {
     return uregex_clone(regexp, pErrorCode);
 }

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -25,7 +25,7 @@ UBreakIterator * __hs_ubrk_safeClone(const UBreakIterator *bi,
     return ubrk_safeClone(bi, stackBuffer, pBufferSize, status);
 }
 
-int32_t __hs_ubrk_current(UBreakIterator *bi)
+int32_t __hs_ubrk_current(const UBreakIterator *bi)
 {
     return ubrk_current(bi);
 }

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -80,7 +80,6 @@ UCollator* __hs_ucol_safeClone(const UCollator *coll,
 int32_t __hs_ucol_getSortKey(const UCollator *coll,
 			     const UChar *source, int32_t sourceLength,
 			     uint8_t *result, int32_t resultLength);
-UBool __hs_ucol_equals(const UCollator *source, const UCollator *target);
 
 /* ucnv.h */
 

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -26,7 +26,7 @@ void __hs_ubrk_setText(UBreakIterator* bi, const UChar *text,
 UBreakIterator * __hs_ubrk_safeClone(const UBreakIterator *bi,
 				     void *stackBuffer, int32_t *pBufferSize,
 				     UErrorCode *status);
-int32_t __hs_ubrk_current(UBreakIterator *bi);
+int32_t __hs_ubrk_current(const UBreakIterator *bi);
 int32_t __hs_ubrk_first(UBreakIterator *bi);
 int32_t __hs_ubrk_last(UBreakIterator *bi);
 int32_t __hs_ubrk_next(UBreakIterator *bi);

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -141,8 +141,8 @@ void __hs_uregex_setTimeLimit(URegularExpression *regexp,
 void __hs_uregex_setStackLimit(URegularExpression *regexp,
 			       int32_t limit, UErrorCode *status);
 void __hs_uregex_close(URegularExpression *regexp);
-URegularExpression *__hs_uregex_clone(URegularExpression *regexp,
-				      UErrorCode *pErrorCode);
+URegularExpression * __hs_uregex_clone(const URegularExpression *regexp,
+				       UErrorCode *pErrorCode);
 const UChar *__hs_uregex_pattern(const URegularExpression *regexp,
 				 int32_t *patLength, UErrorCode *status);
 int32_t __hs_uregex_flags(const URegularExpression *regexp,


### PR DESCRIPTION
Some minor tweaks that ensure continued compatibility with ICU up to the current latest version, which is 55.

The only substantive change is that the reference to `ucol_equals()` - which anyway was always marked as `U_INTERNAL` and should not have been used in the first place - was removed from the C header file. But the `Eq` instance for `Collator` was already removed some time ago, so that function anyway wasn't being used.