### PR TITLE
New module Data.Text.ICU.Spoof

### DIFF
--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -86,20 +86,27 @@ module Data.Text.ICU
     , prefix
     , suffix
     -- * Spoof checking
+    -- $spoof
     , Spoof
+    , SpoofParams(..)
     , S.SpoofCheck(..)
     , S.RestrictionLevel(..)
     , S.SpoofCheckResult(..)
+    -- ** Construction
     , spoof
     , spoofWithParams
+    , spoofFromSource
     , spoofFromSerialized
+    -- ** String checking
     , areConfusable
+    , spoofCheck
     , getSkeleton
+    -- ** Configuration
     , getChecks
     , getAllowedLocales
     , getRestrictionLevel
+    -- ** Persistence
     , serialize
-    , spoofCheck
     ) where
 
 import Data.Text.ICU.Break.Pure
@@ -176,3 +183,14 @@ import Data.Text (Text)
 -- Capturing groups are numbered starting from zero.  Group zero is
 -- always the entire matching text.  Groups greater than zero contain
 -- the text matching each capturing group in a regular expression.
+
+-- $spoof
+--
+-- The 'Spoof' type performs security checks on visually confusable
+-- (spoof) strings.  For the impure spoof checking API (which is
+-- richer, but less easy to use than the pure API), see the
+-- "Data.Text.ICU.Spoof" module.
+--
+-- See <http://unicode.org/reports/tr36/ UTR #36> and
+-- <http://unicode.org/reports/tr39/ UTS #39> for detailed information
+-- about the underlying algorithms and databases used by these functions.

--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -91,9 +91,7 @@ module Data.Text.ICU
     , S.RestrictionLevel(..)
     , S.SpoofCheckResult(..)
     , spoof
-    , spoofWithChecks
-    , spoofWithLevel
-    , spoofWithChecksAndLevel
+    , spoofWithParams
     , areConfusable
     , getSkeleton
     , spoofCheck

--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -92,6 +92,7 @@ module Data.Text.ICU
     , S.SpoofCheckResult(..)
     , spoof
     , spoofWithChecks
+    , spoofWithLevel
     , spoofWithChecksAndLevel
     , areConfusable
     , spoofCheck

--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -85,6 +85,16 @@ module Data.Text.ICU
     , group
     , prefix
     , suffix
+    -- * Spoof checking
+    , Spoof
+    , S.SpoofCheck(..)
+    , S.RestrictionLevel(..)
+    , S.SpoofCheckResult(..)
+    , spoof
+    , spoofWithChecks
+    , spoofWithChecksAndLevel
+    , areConfusable
+    , spoofCheck
     ) where
 
 import Data.Text.ICU.Break.Pure
@@ -93,6 +103,8 @@ import Data.Text.ICU.Internal
 import Data.Text.ICU.Iterator
 import Data.Text.ICU.Normalize
 import Data.Text.ICU.Regex.Pure
+import qualified Data.Text.ICU.Spoof as S
+import Data.Text.ICU.Spoof.Pure
 import Data.Text.ICU.Text
 #if defined(__HADDOCK__)
 import Data.Text.Foreign

--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -92,8 +92,13 @@ module Data.Text.ICU
     , S.SpoofCheckResult(..)
     , spoof
     , spoofWithParams
+    , spoofFromSerialized
     , areConfusable
     , getSkeleton
+    , getChecks
+    , getAllowedLocales
+    , getRestrictionLevel
+    , serialize
     , spoofCheck
     ) where
 

--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -95,6 +95,7 @@ module Data.Text.ICU
     , spoofWithLevel
     , spoofWithChecksAndLevel
     , areConfusable
+    , getSkeleton
     , spoofCheck
     ) where
 

--- a/Data/Text/ICU/BitMask.hs
+++ b/Data/Text/ICU/BitMask.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DefaultSignatures, ScopedTypeVariables #-}
+
+-- From http://stackoverflow.com/a/15911213
+
+module Data.Text.ICU.BitMask
+       (
+    -- * Bit mask twiddling API
+    -- $api
+    -- * Types
+      ToBitMask
+    -- * Functions
+    , fromBitMask
+    , toBitMask
+    ) where
+
+
+import Data.Bits ((.&.), (.|.), shiftL)
+import Control.Monad (msum, mzero)
+
+class ToBitMask a where
+  toBitMask :: a -> Int
+  -- | Using a DefaultSignatures extension to declare a default signature with
+  -- an `Enum` constraint without affecting the constraints of the class itself.
+  default toBitMask :: Enum a => a -> Int
+  toBitMask = shiftL 1 . fromEnum
+
+instance ( ToBitMask a ) => ToBitMask [a] where
+    toBitMask = foldr (.|.) 0 . map toBitMask
+
+-- | Not making this a typeclass, since it already generalizes over all
+-- imaginable instances with help of `MonadPlus`.
+fromBitMask ::
+    ( Enum a, Bounded a, ToBitMask a ) =>
+        Int -> [a]
+fromBitMask bm = msum $ map asInBM $ enumFrom minBound where
+  asInBM a = if isInBitMask bm a then return a else mzero
+
+isInBitMask :: ( ToBitMask a ) => Int -> a -> Bool
+isInBitMask bm a = let aBM = toBitMask a in aBM == aBM .&. bm

--- a/Data/Text/ICU/BitMask.hs
+++ b/Data/Text/ICU/BitMask.hs
@@ -10,11 +10,14 @@ module Data.Text.ICU.BitMask
       ToBitMask
     -- * Functions
     , fromBitMask
+    , highestValueInBitMask
+    , lowestValueInBitMask
     , toBitMask
     ) where
 
 
 import Data.Bits ((.&.), (.|.), shiftL)
+import Data.Maybe (listToMaybe)
 import Control.Monad (msum, mzero)
 
 class ToBitMask a where
@@ -34,6 +37,16 @@ fromBitMask ::
         Int -> [a]
 fromBitMask bm = msum $ map asInBM $ enumFrom minBound where
   asInBM a = if isInBitMask bm a then return a else mzero
+
+lowestValueInBitMask ::
+    ( Enum a, Bounded a, ToBitMask a ) =>
+        Int -> Maybe a
+lowestValueInBitMask = listToMaybe . fromBitMask
+
+highestValueInBitMask ::
+    ( Enum a, Bounded a, ToBitMask a ) =>
+        Int -> Maybe a
+highestValueInBitMask = listToMaybe . reverse . fromBitMask
 
 isInBitMask :: ( ToBitMask a ) => Int -> a -> Bool
 isInBitMask bm a = let aBM = toBitMask a in aBM == aBM .&. bm

--- a/Data/Text/ICU/BitMask.hs
+++ b/Data/Text/ICU/BitMask.hs
@@ -7,16 +7,18 @@ module Data.Text.ICU.BitMask
     -- * Bit mask twiddling API
     -- $api
     -- * Types
-      ToBitMask
+      ToBitMask(..)
     -- * Functions
     , fromBitMask
     , highestValueInBitMask
-    , toBitMask
     ) where
-
 
 import Data.Bits ((.&.), (.|.))
 import Data.Maybe (listToMaybe)
+
+-- $api
+-- Conversion to and from enumerated types representable as
+-- a compact bitmask.
 
 class ToBitMask a where
   toBitMask :: a -> Int

--- a/Data/Text/ICU/Spoof.hsc
+++ b/Data/Text/ICU/Spoof.hsc
@@ -108,7 +108,7 @@ makeSpoofCheckResult c =
       case restrictionLevel of
         Nothing -> CheckFailed spoofChecks
         Just l -> CheckFailedWithRestrictionLevel spoofChecks l
-  where spoofChecks = fromBitMask $ fromIntegral c
+  where spoofChecks = fromBitMask $ fromIntegral $ c .&. #const USPOOF_ALL_CHECKS
         restrictionValue = c .&. #const USPOOF_RESTRICTION_LEVEL_MASK
         restrictionLevel = listToMaybe $ fromBitMask $ fromIntegral $ restrictionValue
 

--- a/Data/Text/ICU/Spoof.hsc
+++ b/Data/Text/ICU/Spoof.hsc
@@ -1,0 +1,191 @@
+{-# LANGUAGE BangPatterns, CPP, DeriveDataTypeable, ForeignFunctionInterface #-}
+-- |
+-- Module      : Data.Text.ICU.Spoof
+-- Copyright   : (c) 2015 Ben Hamilton
+--
+-- License     : BSD-style
+-- Maintainer  : bgertzfield@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- String spoofing (confusability) checks for Unicode, implemented as bindings to
+-- the International Components for Unicode (ICU) uspoof library.
+
+module Data.Text.ICU.Spoof
+    (
+    -- * Unicode spoof checking API
+    -- $api
+    -- * Types
+      MSpoof
+    , Spoof
+    , SpoofCheck(..)
+    , SpoofCheckResult(..)
+    , RestrictionLevel(..)
+    -- * Functions
+    , open
+    , getSkeleton
+    , getChecks
+    , setChecks
+    , getRestrictionLevel
+    , setRestrictionLevel
+    , areConfusable
+    , spoofCheck
+    ) where
+
+#include <unicode/uspoof.h>
+
+import Control.Applicative
+import Data.Bits ((.&.))
+import Data.Int (Int32)
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import Data.Text.Foreign (fromPtr, useAsPtr)
+import Data.Text.ICU.BitMask (ToBitMask, fromBitMask, toBitMask)
+import Data.Text.ICU.Spoof.Internal (MSpoof, USpoof, Spoof, withSpoof, wrap)
+import Data.Text.ICU.Error.Internal (UErrorCode, handleError)
+import Data.Text.ICU.Internal (UChar)
+import Foreign.Marshal.Array (allocaArray)
+import Foreign.Ptr (Ptr, nullPtr)
+
+-- $api
+--
+
+data SpoofCheck = SingleScriptConfusable
+                | MixedScriptConfusable
+                | WholeScriptConfusable
+                | AnyCase
+                | RestrictionLevel
+                | Invisible
+                | CharLimit
+                | MixedNumbers
+                | AllChecks
+                | AuxInfo
+                deriving (Bounded, Enum, Eq, Show)
+
+instance ToBitMask SpoofCheck where
+  toBitMask SingleScriptConfusable = #const USPOOF_SINGLE_SCRIPT_CONFUSABLE
+  toBitMask MixedScriptConfusable = #const USPOOF_MIXED_SCRIPT_CONFUSABLE
+  toBitMask WholeScriptConfusable = #const USPOOF_WHOLE_SCRIPT_CONFUSABLE
+  toBitMask AnyCase = #const USPOOF_ANY_CASE
+  toBitMask RestrictionLevel = #const USPOOF_RESTRICTION_LEVEL
+  toBitMask Invisible = #const USPOOF_INVISIBLE
+  toBitMask CharLimit = #const USPOOF_CHAR_LIMIT
+  toBitMask MixedNumbers = #const USPOOF_MIXED_NUMBERS
+  toBitMask AllChecks = #const USPOOF_ALL_CHECKS
+  toBitMask AuxInfo = #const USPOOF_AUX_INFO
+
+type USpoofCheck = Int32
+
+data RestrictionLevel = ASCII
+                      | SingleScriptRestrictive
+                      | HighlyRestrictive
+                      | ModeratelyRestrictive
+                      | MinimallyRestrictive
+                      | Unrestrictive
+                      deriving (Bounded, Enum, Eq, Show)
+
+instance ToBitMask RestrictionLevel where
+  toBitMask ASCII = #const USPOOF_ASCII
+  toBitMask SingleScriptRestrictive = #const USPOOF_SINGLE_SCRIPT_RESTRICTIVE
+  toBitMask HighlyRestrictive = #const USPOOF_HIGHLY_RESTRICTIVE
+  toBitMask ModeratelyRestrictive = #const USPOOF_MODERATELY_RESTRICTIVE
+  toBitMask MinimallyRestrictive = #const USPOOF_MINIMALLY_RESTRICTIVE
+  toBitMask Unrestrictive = #const USPOOF_UNRESTRICTIVE
+
+type URestrictionLevel = Int32
+
+data SpoofCheckResult = CheckOK
+                      | CheckFailed [SpoofCheck]
+                      | CheckFailedWithRestrictionLevel { checks :: [SpoofCheck],
+                                                           level :: RestrictionLevel }
+                deriving (Eq, Show)
+
+makeSpoofCheckResult :: USpoofCheck -> SpoofCheckResult
+makeSpoofCheckResult c =
+  case spoofChecks of
+    [] -> CheckOK
+    _ ->
+      case restrictionLevel of
+        Nothing -> CheckFailed spoofChecks
+        Just l -> CheckFailedWithRestrictionLevel spoofChecks l
+  where spoofChecks = fromBitMask $ fromIntegral c
+        restrictionValue = c .&. #const USPOOF_RESTRICTION_LEVEL_MASK
+        restrictionLevel = listToMaybe $ fromBitMask $ fromIntegral $ restrictionValue
+
+-- | Open a spoof checker for checking Unicode strings for lookalike security issues.
+open :: IO MSpoof
+open = wrap =<< (handleError uspoof_open)
+
+-- | Get the checks performed by a spoof checker.
+getChecks :: MSpoof -> IO SpoofCheckResult
+getChecks s = do
+  withSpoof s $ \sptr ->
+    makeSpoofCheckResult <$> handleError (uspoof_getChecks sptr)
+
+-- | Configure the checks performed by a spoof checker.
+setChecks :: MSpoof -> [SpoofCheck] -> IO ()
+setChecks s c = do
+  withSpoof s $ \sptr ->
+    handleError $ uspoof_setChecks sptr . fromIntegral $ toBitMask c
+
+-- | Get the restriction level of a spoof checker.
+getRestrictionLevel :: MSpoof -> IO (Maybe RestrictionLevel)
+getRestrictionLevel s = do
+  withSpoof s $ \sptr ->
+    (listToMaybe . fromBitMask . fromIntegral) <$> uspoof_getRestrictionLevel sptr
+
+-- | Configure the restriction level of a spoof checker.
+setRestrictionLevel :: MSpoof -> RestrictionLevel -> IO ()
+setRestrictionLevel s l = do
+  withSpoof s $ \sptr ->
+    uspoof_setRestrictionLevel sptr . fromIntegral $ toBitMask l
+
+-- | Check if two strings could be confused with each other.
+areConfusable :: MSpoof -> Text -> Text -> IO SpoofCheckResult
+areConfusable s t1 t2 = do
+  withSpoof s $ \sptr ->
+    useAsPtr t1 $ \t1ptr t1len ->
+      useAsPtr t2 $ \t2ptr t2len ->
+        makeSpoofCheckResult <$>
+          handleError (uspoof_areConfusable sptr t1ptr (fromIntegral t1len) t2ptr (fromIntegral t2len))
+
+-- | Generate a re-usable "skeleton" to check if an identifier is confusable
+-- with some large set of existing identifiers.
+getSkeleton :: MSpoof -> [SpoofCheck] -> Text -> IO Text
+getSkeleton s c t = do
+  withSpoof s $ \sptr ->
+    useAsPtr t $ \tptr tlen -> do
+      allocaArray (fromIntegral tlen) $ \destptr ->
+        (fromPtr destptr . fromIntegral) =<<
+          handleError (uspoof_getSkeleton sptr (fromIntegral $ toBitMask c) tptr (fromIntegral tlen) destptr (fromIntegral tlen))
+
+-- | Check if a string could be confused with any other.
+spoofCheck :: MSpoof -> Text -> IO SpoofCheckResult
+spoofCheck s t = do
+  withSpoof s $ \sptr ->
+    useAsPtr t $ \tptr tlen ->
+      makeSpoofCheckResult <$> handleError (uspoof_check sptr tptr (fromIntegral tlen) nullPtr)
+
+foreign import ccall unsafe "hs_text_icu.h __hs_uspoof_open" uspoof_open
+    :: Ptr UErrorCode -> IO (Ptr USpoof)
+
+foreign import ccall unsafe "hs_text_icu.h __hs_uspoof_getChecks" uspoof_getChecks
+    :: Ptr USpoof -> Ptr UErrorCode -> IO USpoofCheck
+
+foreign import ccall unsafe "hs_text_icu.h __hs_uspoof_setChecks" uspoof_setChecks
+    :: Ptr USpoof -> USpoofCheck -> Ptr UErrorCode -> IO ()
+
+foreign import ccall unsafe "hs_text_icu.h __hs_uspoof_getRestrictionLevel" uspoof_getRestrictionLevel
+    :: Ptr USpoof -> IO URestrictionLevel
+
+foreign import ccall unsafe "hs_text_icu.h __hs_uspoof_setRestrictionLevel" uspoof_setRestrictionLevel
+    :: Ptr USpoof -> URestrictionLevel -> IO ()
+
+foreign import ccall unsafe "hs_text_icu.h __hs_uspoof_areConfusable" uspoof_areConfusable
+    :: Ptr USpoof -> Ptr UChar -> Int32 -> Ptr UChar -> Int32 -> Ptr UErrorCode -> IO USpoofCheck
+
+foreign import ccall unsafe "hs_text_icu.h __hs_uspoof_check" uspoof_check
+    :: Ptr USpoof -> Ptr UChar -> Int32 -> Ptr Int32 -> Ptr UErrorCode -> IO USpoofCheck
+
+foreign import ccall unsafe "hs_text_icu.h __hs_uspoof_getSkeleton" uspoof_getSkeleton
+    :: Ptr USpoof -> USpoofCheck -> Ptr UChar -> Int32 -> Ptr UChar -> Int32 -> Ptr UErrorCode -> IO Int32

--- a/Data/Text/ICU/Spoof/Internal.hs
+++ b/Data/Text/ICU/Spoof/Internal.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DeriveDataTypeable, EmptyDataDecls, ForeignFunctionInterface #-}
+-- |
+-- Module      : Data.Text.ICU.Spoof.Internal
+-- Copyright   : (c) 2015 Ben Hamilton
+--
+-- License     : BSD-style
+-- Maintainer  : bgertzfield@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Internals of the spoofability check infrastructure.
+
+module Data.Text.ICU.Spoof.Internal
+    (
+    -- * Unicode collation API
+      MSpoof(..)
+    , Spoof(..)
+    , USpoof
+    , withSpoof
+    , wrap
+    ) where
+
+import Data.Typeable (Typeable)
+import Foreign.ForeignPtr (ForeignPtr, newForeignPtr, withForeignPtr)
+import Foreign.Ptr (FunPtr, Ptr)
+
+-- $api
+--
+
+data USpoof
+
+-- | Spoof checker type.
+data MSpoof = MSpoof {-# UNPACK #-} !(ForeignPtr USpoof)
+                 deriving (Typeable)
+
+-- | Spoof checker type.
+newtype Spoof = C MSpoof
+    deriving (Typeable)
+
+withSpoof :: MSpoof -> (Ptr USpoof -> IO a) -> IO a
+withSpoof (MSpoof spoof) = withForeignPtr spoof
+{-# INLINE withSpoof #-}
+
+wrap :: Ptr USpoof -> IO MSpoof
+wrap = fmap MSpoof . newForeignPtr uspoof_close
+{-# INLINE wrap #-}
+
+foreign import ccall unsafe "hs_text_icu.h &__hs_uspoof_close" uspoof_close
+    :: FunPtr (Ptr USpoof -> IO ())

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -72,7 +72,7 @@ spoofCheck (C s) t = unsafePerformIO $ S.spoofCheck s t
 
 -- | Get a skeleton representation of a string to directly compare for
 -- spoofability with another string.
-getSkeleton :: Spoof -> [S.SpoofCheck] -> Text -> Text
-getSkeleton (C s) c t = unsafePerformIO $ S.getSkeleton s c t
+getSkeleton :: Spoof -> Maybe S.SkeletonTypeOverride -> Text -> Text
+getSkeleton (C s) o t = unsafePerformIO $ S.getSkeleton s o t
 
 {-# INLINE spoofCheck #-}

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable, ForeignFunctionInterface #-}
 -- |
 -- Module      : Data.Text.ICU.Spoof.Pure
 -- Copyright   : (c) 2015 Ben Hamilton
@@ -17,20 +16,23 @@
 
 module Data.Text.ICU.Spoof.Pure
     (
-    -- * Unicode spoof checking API
-    -- $api
+    -- * Types
       Spoof
     , SpoofParams(..)
     , spoof
     , spoofWithParams
+    , spoofFromSource
     , spoofFromSerialized
+    -- * String spoof checks
     , areConfusable
+    , getSkeleton
+    , spoofCheck
+    -- * Configuration
     , getAllowedLocales
     , getChecks
-    , getSkeleton
     , getRestrictionLevel
+    -- * Persistence
     , serialize
-    , spoofCheck
     ) where
 
 import Data.ByteString (ByteString)
@@ -40,63 +42,105 @@ import Data.Text.ICU.Spoof.Internal (Spoof(..))
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Data.Text.ICU.Spoof as S
 
-data SpoofParams = SpoofParams {
-     spoofChecks :: Maybe [S.SpoofCheck]
-   , level :: Maybe S.RestrictionLevel
-   , locales :: Maybe [String]
+data SpoofParams
+  -- | Used to configure a 'Spoof' checker via 'spoofWithParams'.
+  = SpoofParams {
+    -- | Optional 'S.SpoofCheck's to perform on a string. By default, performs
+    -- all checks except 'CharLimit'.
+    spoofChecks :: Maybe [S.SpoofCheck]
+    -- | Optional 'S.RestrictionLevel' to which characters in the string will
+    -- be limited. By default, uses 'HighlyRestrictive'.
+  , level :: Maybe S.RestrictionLevel
+    -- | Optional locale(s) whose scripts will be used to limit the
+    -- set of allowed characters in a string. If set, automatically
+    -- enables the 'CharLimit' spoof check.
+  , locales :: Maybe [String]
 } deriving (Show, Eq)
 
--- $api
---
-
--- | Create an immutable spoof checker with default options.
-spoof :: Spoof
-spoof = unsafePerformIO $ C `fmap` S.open
-
--- | Create an immutable spoof checker with specific options.
-spoofWithParams :: SpoofParams -> Spoof
-spoofWithParams (SpoofParams c lev loc) = unsafePerformIO $ do
-  s <- S.open
+applySpoofParams :: SpoofParams -> S.MSpoof -> S.MSpoof
+applySpoofParams (SpoofParams c lev loc) s = unsafePerformIO $ do
   forM_ c (S.setChecks s)
   forM_ lev (S.setRestrictionLevel s)
   forM_ loc (S.setAllowedLocales s)
-  return (C s)
+  return s
 
--- | Create an immutable spoof checker from a previously-serialized instance.
-spoofFromSerialized :: ByteString -> Spoof
-spoofFromSerialized b = unsafePerformIO $ C `fmap` S.openFromSerialized b
+-- | Open an immutable 'Spoof' checker with default options (all
+-- 'S.SpoofCheck's except 'CharLimit').
+spoof :: Spoof
+spoof = unsafePerformIO $ S `fmap` S.open
+
+-- | Open an immutable 'Spoof' checker with specific 'SpoofParams'
+-- to control its behavior.
+spoofWithParams :: SpoofParams -> Spoof
+spoofWithParams p = unsafePerformIO $ do
+  s <- S.open
+  return (S $ applySpoofParams p s)
+
+-- | Open a immutable 'Spoof' checker with specific 'SpoofParams'
+-- to control its behavior and custom rules given the UTF-8 encoded
+-- contents of the @confusables.txt@ and @confusablesWholeScript.txt@
+-- files as described in <http://unicode.org/reports/tr39/ Unicode UAX #39>.
+spoofFromSource :: (ByteString, ByteString) -> SpoofParams -> Spoof
+spoofFromSource (confusables, confusablesWholeScript) p = unsafePerformIO $ do
+  s <- S.openFromSource (confusables, confusablesWholeScript)
+  return (S $ applySpoofParams p s)
+
+-- | Create an immutable spoof checker with specific 'SpoofParams'
+-- to control its behavior and custom rules previously returned
+-- by 'serialize'.
+spoofFromSerialized :: ByteString -> SpoofParams -> Spoof
+spoofFromSerialized b p = unsafePerformIO $ do
+  s <- S.openFromSerialized b
+  return (S $ applySpoofParams p s)
 
 -- | Check two strings for confusability.
 areConfusable :: Spoof -> Text -> Text -> S.SpoofCheckResult
-areConfusable (C s) t1 t2 = unsafePerformIO $ S.areConfusable s t1 t2
+areConfusable (S s) t1 t2 = unsafePerformIO $ S.areConfusable s t1 t2
 
 -- | Check a string for spoofing issues.
 spoofCheck :: Spoof -> Text -> S.SpoofCheckResult
-spoofCheck (C s) t = unsafePerformIO $ S.spoofCheck s t
+spoofCheck (S s) t = unsafePerformIO $ S.spoofCheck s t
 
--- | Get a skeleton representation of a string to directly compare for
--- spoofability with another string.
+-- | Generates re-usable \"skeleton\" strings which can be used (via
+-- Unicode equality) to check if an identifier is confusable
+-- with some large set of existing identifiers.
+--
+-- If you cache the returned strings in storage, you /must/ invalidate
+-- your cache any time the underlying confusables database changes
+-- (i.e., on ICU upgrade).
+--
+-- By default, assumes all input strings have been passed through
+-- 'toCaseFold' and are lower-case. To change this, pass
+-- 'SkeletonAnyCase'.
+--
+-- By default, builds skeletons which catch visually confusable
+-- characters across multiple scripts.  Pass 'SkeletonSingleScript' to
+-- override that behavior and build skeletons which catch visually
+-- confusable characters across single scripts.
 getSkeleton :: Spoof -> Maybe S.SkeletonTypeOverride -> Text -> Text
-getSkeleton (C s) o t = unsafePerformIO $ S.getSkeleton s o t
+getSkeleton (S s) o t = unsafePerformIO $ S.getSkeleton s o t
 
 -- | Gets the restriction level currently configured in the spoof
 -- checker, if present.
 getRestrictionLevel :: Spoof -> Maybe S.RestrictionLevel
-getRestrictionLevel (C s) = unsafePerformIO $ S.getRestrictionLevel s
+getRestrictionLevel (S s) = unsafePerformIO $ S.getRestrictionLevel s
 
 -- | Gets the checks currently configured in the spoof checker.
 getChecks :: Spoof -> [S.SpoofCheck]
-getChecks (C s) = unsafePerformIO $ S.getChecks s
+getChecks (S s) = unsafePerformIO $ S.getChecks s
 
 -- | Gets the locales whose scripts are currently allowed by the spoof
--- checker.  (We don't use LocaleName since the root and default
+-- checker.  (We don't use 'LocaleName' since the root and default
 -- locales have no meaning here.)
 getAllowedLocales :: Spoof -> [String]
-getAllowedLocales (C s) = unsafePerformIO $ S.getAllowedLocales s
+getAllowedLocales (S s) = unsafePerformIO $ S.getAllowedLocales s
 
--- | Serializes the configured spoof checker so it can later be
--- created with openFromSerialized.
+-- | Serializes the rules in this spoof checker to a byte array,
+-- suitable for re-use by 'spoofFromSerialized'.
+--
+-- Only includes any data provided to 'openFromSource'. Does not
+-- include any other state or configuration.
 serialize :: Spoof -> ByteString
-serialize (C s) = unsafePerformIO $ S.serialize s
+serialize (S s) = unsafePerformIO $ S.serialize s
 
 {-# INLINE spoofCheck #-}

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DeriveDataTypeable, ForeignFunctionInterface #-}
+-- |
+-- Module      : Data.Text.ICU.Spoof.Pure
+-- Copyright   : (c) 2015 Ben Hamilton
+--
+-- License     : BSD-style
+-- Maintainer  : bgertzfield@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Pure string spoof checking functions for Unicode, implemented as
+-- bindings to the International Components for Unicode (ICU)
+-- libraries.
+--
+-- For the impure spoof checking API (which is richer, but less easy to
+-- use), see the "Data.Text.ICU.Spoof" module.
+
+module Data.Text.ICU.Spoof.Pure
+    (
+    -- * Unicode spoof checking API
+    -- $api
+      Spoof
+    , spoof
+    , spoofWithChecks
+    , spoofWithChecksAndLevel
+    , areConfusable
+    , spoofCheck
+    ) where
+
+import Data.Text (Text)
+import Data.Text.ICU.Spoof.Internal (Spoof(..))
+import System.IO.Unsafe (unsafePerformIO)
+import qualified Data.Text.ICU.Spoof as S
+
+-- $api
+--
+
+-- | Create an immutable spoof checker with default options.
+spoof :: Spoof
+spoof = unsafePerformIO $ C `fmap` S.open
+
+-- | Create an immutable spoof checker with specific options.
+spoofWithChecks :: [S.SpoofCheck] -> Spoof
+spoofWithChecks checks = unsafePerformIO $ do
+  s <- S.open
+  S.setChecks s checks
+  return (C s)
+
+-- | Create an immutable spoof checker with specific options and restriction level.
+spoofWithChecksAndLevel :: [S.SpoofCheck] -> S.RestrictionLevel -> Spoof
+spoofWithChecksAndLevel checks level = unsafePerformIO $ do
+  s <- S.open
+  S.setChecks s checks
+  S.setRestrictionLevel s level
+  return (C s)
+
+-- | Check two strings for confusability.
+areConfusable :: Spoof -> Text -> Text -> S.SpoofCheckResult
+areConfusable (C s) t1 t2 = unsafePerformIO $ S.areConfusable s t1 t2
+
+-- | Check a string for spoofing issues.
+spoofCheck :: Spoof -> Text -> S.SpoofCheckResult
+spoofCheck (C s) t = unsafePerformIO $ S.spoofCheck s t
+
+{-# INLINE spoofCheck #-}

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -34,6 +34,7 @@ module Data.Text.ICU.Spoof.Pure
     ) where
 
 import Data.ByteString (ByteString)
+import Data.Foldable (forM_)
 import Data.Text (Text)
 import Data.Text.ICU.Spoof.Internal (Spoof(..))
 import System.IO.Unsafe (unsafePerformIO)
@@ -56,15 +57,9 @@ spoof = unsafePerformIO $ C `fmap` S.open
 spoofWithParams :: SpoofParams -> Spoof
 spoofWithParams (SpoofParams c lev loc) = unsafePerformIO $ do
   s <- S.open
-  case c of
-    Just c' -> S.setChecks s c'
-    Nothing -> return ()
-  case lev of
-    Just lev' -> S.setRestrictionLevel s lev'
-    Nothing -> return ()
-  case loc of
-    Just loc' -> S.setAllowedLocales s loc'
-    Nothing -> return ()
+  forM_ c (S.setChecks s)
+  forM_ lev (S.setRestrictionLevel s)
+  forM_ loc (S.setAllowedLocales s)
   return (C s)
 
 -- | Create an immutable spoof checker from a previously-serialized instance.

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -79,7 +79,8 @@ spoofCheck (C s) t = unsafePerformIO $ S.spoofCheck s t
 getSkeleton :: Spoof -> Maybe S.SkeletonTypeOverride -> Text -> Text
 getSkeleton (C s) o t = unsafePerformIO $ S.getSkeleton s o t
 
--- | Gets the restriction level currently configured in the spoof checker, if present.
+-- | Gets the restriction level currently configured in the spoof
+-- checker, if present.
 getRestrictionLevel :: Spoof -> Maybe S.RestrictionLevel
 getRestrictionLevel (C s) = unsafePerformIO $ S.getRestrictionLevel s
 
@@ -88,11 +89,13 @@ getChecks :: Spoof -> [S.SpoofCheck]
 getChecks (C s) = unsafePerformIO $ S.getChecks s
 
 -- | Gets the locales currently allowed the spoof checker.
--- (We don't use LocaleName since the root and default locales have no meaning here.)
+-- (We don't use LocaleName since the root and default locales have no
+-- meaning here.)
 getAllowedLocales :: Spoof -> [String]
 getAllowedLocales (C s) = unsafePerformIO $ S.getAllowedLocales s
 
--- | Serializes the configured spoof checker so it can later be created with openFromSerialized.
+-- | Serializes the configured spoof checker so it can later be
+-- created with openFromSerialized.
 serialize :: Spoof -> ByteString
 serialize (C s) = unsafePerformIO $ S.serialize s
 

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -23,13 +23,18 @@ module Data.Text.ICU.Spoof.Pure
     , SpoofParams(..)
     , spoof
     , spoofWithParams
+    , spoofFromSerialized
     , areConfusable
+    , getAllowedLocales
+    , getChecks
     , getSkeleton
+    , getRestrictionLevel
+    , serialize
     , spoofCheck
     ) where
 
+import Data.ByteString (ByteString)
 import Data.Text (Text)
-import Data.Text.ICU.Internal (LocaleName(..))
 import Data.Text.ICU.Spoof.Internal (Spoof(..))
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Data.Text.ICU.Spoof as S
@@ -37,7 +42,7 @@ import qualified Data.Text.ICU.Spoof as S
 data SpoofParams = SpoofParams {
      spoofChecks :: Maybe [S.SpoofCheck]
    , level :: Maybe S.RestrictionLevel
-   , locales :: Maybe [LocaleName]
+   , locales :: Maybe [String]
 } deriving (Show, Eq)
 
 -- $api
@@ -62,6 +67,10 @@ spoofWithParams (SpoofParams c lev loc) = unsafePerformIO $ do
     Nothing -> return ()
   return (C s)
 
+-- | Create an immutable spoof checker from a previously-serialized instance.
+spoofFromSerialized :: ByteString -> Spoof
+spoofFromSerialized b = unsafePerformIO $ C `fmap` S.openFromSerialized b
+
 -- | Check two strings for confusability.
 areConfusable :: Spoof -> Text -> Text -> S.SpoofCheckResult
 areConfusable (C s) t1 t2 = unsafePerformIO $ S.areConfusable s t1 t2
@@ -74,5 +83,22 @@ spoofCheck (C s) t = unsafePerformIO $ S.spoofCheck s t
 -- spoofability with another string.
 getSkeleton :: Spoof -> Maybe S.SkeletonTypeOverride -> Text -> Text
 getSkeleton (C s) o t = unsafePerformIO $ S.getSkeleton s o t
+
+-- | Gets the restriction level currently configured in the spoof checker, if present.
+getRestrictionLevel :: Spoof -> Maybe S.RestrictionLevel
+getRestrictionLevel (C s) = unsafePerformIO $ S.getRestrictionLevel s
+
+-- | Gets the checks currently configured in the spoof checker.
+getChecks :: Spoof -> [S.SpoofCheck]
+getChecks (C s) = unsafePerformIO $ S.getChecks s
+
+-- | Gets the locales currently allowed the spoof checker.
+-- (We don't use LocaleName since the root and default locales have no meaning here.)
+getAllowedLocales :: Spoof -> [String]
+getAllowedLocales (C s) = unsafePerformIO $ S.getAllowedLocales s
+
+-- | Serializes the configured spoof checker so it can later be created with openFromSerialized.
+serialize :: Spoof -> ByteString
+serialize (C s) = unsafePerformIO $ S.serialize s
 
 {-# INLINE spoofCheck #-}

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -25,6 +25,7 @@ module Data.Text.ICU.Spoof.Pure
     , spoofWithLevel
     , spoofWithChecksAndLevel
     , areConfusable
+    , getSkeleton
     , spoofCheck
     ) where
 
@@ -68,5 +69,10 @@ areConfusable (C s) t1 t2 = unsafePerformIO $ S.areConfusable s t1 t2
 -- | Check a string for spoofing issues.
 spoofCheck :: Spoof -> Text -> S.SpoofCheckResult
 spoofCheck (C s) t = unsafePerformIO $ S.spoofCheck s t
+
+-- | Get a skeleton representation of a string to directly compare for
+-- spoofability with another string.
+getSkeleton :: Spoof -> [S.SpoofCheck] -> Text -> Text
+getSkeleton (C s) c t = unsafePerformIO $ S.getSkeleton s c t
 
 {-# INLINE spoofCheck #-}

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -22,6 +22,7 @@ module Data.Text.ICU.Spoof.Pure
       Spoof
     , spoof
     , spoofWithChecks
+    , spoofWithLevel
     , spoofWithChecksAndLevel
     , areConfusable
     , spoofCheck
@@ -47,6 +48,12 @@ spoofWithChecks checks = unsafePerformIO $ do
   return (C s)
 
 -- | Create an immutable spoof checker with specific options and restriction level.
+spoofWithLevel :: S.RestrictionLevel -> Spoof
+spoofWithLevel level = unsafePerformIO $ do
+  s <- S.open
+  S.setRestrictionLevel s level
+  return (C s)
+
 spoofWithChecksAndLevel :: [S.SpoofCheck] -> S.RestrictionLevel -> Spoof
 spoofWithChecksAndLevel checks level = unsafePerformIO $ do
   s <- S.open

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -88,9 +88,9 @@ getRestrictionLevel (C s) = unsafePerformIO $ S.getRestrictionLevel s
 getChecks :: Spoof -> [S.SpoofCheck]
 getChecks (C s) = unsafePerformIO $ S.getChecks s
 
--- | Gets the locales currently allowed the spoof checker.
--- (We don't use LocaleName since the root and default locales have no
--- meaning here.)
+-- | Gets the locales whose scripts are currently allowed by the spoof
+-- checker.  (We don't use LocaleName since the root and default
+-- locales have no meaning here.)
 getAllowedLocales :: Spoof -> [String]
 getAllowedLocales (C s) = unsafePerformIO $ S.getAllowedLocales s
 

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -455,23 +455,29 @@ USpoofChecker *__hs_uspoof_open(UErrorCode *status)
     return uspoof_open(status);
 }
 
-USpoofChecker *__hs_uspoof_openFromSerialized(const void *data, int32_t length, int32_t *pActualLength,
+USpoofChecker *__hs_uspoof_openFromSerialized(const void *data, int32_t length,
+                                              int32_t *pActualLength,
                                               UErrorCode *status)
 {
     return uspoof_openFromSerialized(data, length, pActualLength, status);
 }
 
-USpoofChecker *__hs_uspoof_openFromSource(const char *confusables, int32_t confusablesLen,
-                                          const char *confusablesWholeScript, int32_t confusablesWholeScriptLen,
-                                          int32_t *errType, int32_t *unused, /* really UParseError */
+USpoofChecker *__hs_uspoof_openFromSource(const char *confusables,
+                                          int32_t confusablesLen,
+                                          const char *confusablesWholeScript,
+                                          int32_t confusablesWholeScriptLen,
+                                          int32_t *errType,
+                                          int32_t *unused, /* UParseError * */
                                           UErrorCode *status)
 {
     return uspoof_openFromSource(confusables, confusablesLen,
-                                 confusablesWholeScript, confusablesWholeScriptLen,
+                                 confusablesWholeScript,
+                                 confusablesWholeScriptLen,
                                  errType, NULL, status);
 }
 
-void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks, UErrorCode *status)
+void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks,
+                           UErrorCode *status)
 {
     uspoof_setChecks(sc, checks, status);
 }
@@ -491,7 +497,8 @@ URestrictionLevel __hs_uspoof_getRestrictionLevel(const USpoofChecker *sc)
     return uspoof_getRestrictionLevel(sc);
 }
 
-void __hs_uspoof_setAllowedLocales(USpoofChecker *sc, const char *localesList, UErrorCode *status)
+void __hs_uspoof_setAllowedLocales(USpoofChecker *sc, const char *localesList,
+                                   UErrorCode *status)
 {
     uspoof_setAllowedLocales(sc, localesList, status);
 }
@@ -524,7 +531,8 @@ int32_t __hs_uspoof_getSkeleton(USpoofChecker *sc,
     return uspoof_getSkeleton(sc, type, id, length, dest, destCapacity, status);
 }
 
-int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity, UErrorCode *status)
+int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity,
+                              UErrorCode *status)
 {
     return uspoof_serialize(sc, data, capacity, status);
 }

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -467,13 +467,16 @@ USpoofChecker *__hs_uspoof_openFromSource(const char *confusables,
                                           const char *confusablesWholeScript,
                                           int32_t confusablesWholeScriptLen,
                                           int32_t *errType,
-                                          int32_t *unused, /* UParseError * */
+                                          UParseError *parseError,
                                           UErrorCode *status)
 {
+    // Work around missing call to umtx_initOnce() in uspoof_openFromSource()
+    // causing crash when gNfdNormalizer is accessed
+    uspoof_getInclusionSet(status);
     return uspoof_openFromSource(confusables, confusablesLen,
                                  confusablesWholeScript,
                                  confusablesWholeScriptLen,
-                                 errType, NULL, status);
+                                 errType, parseError, status);
 }
 
 void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks,

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -455,6 +455,16 @@ USpoofChecker *__hs_uspoof_open(UErrorCode *status)
     return uspoof_open(status);
 }
 
+USpoofChecker *__hs_uspoof_openFromSource(const char *confusables, int32_t confusablesLen,
+                                          const char *confusablesWholeScript, int32_t confusablesWholeScriptLen,
+                                          int32_t *errType, int32_t *unused, /* really UParseError */
+                                          UErrorCode *status)
+{
+    return uspoof_openFromSource(confusables, confusablesLen,
+                                 confusablesWholeScript, confusablesWholeScriptLen,
+                                 errType, NULL, status);
+}
+
 void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks, UErrorCode *status)
 {
     uspoof_setChecks(sc, checks, status);

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -455,6 +455,12 @@ USpoofChecker *__hs_uspoof_open(UErrorCode *status)
     return uspoof_open(status);
 }
 
+USpoofChecker *__hs_uspoof_openFromSerialized(const void *data, int32_t length, int32_t *pActualLength,
+                                              UErrorCode *status)
+{
+    return uspoof_openFromSerialized(data, length, pActualLength, status);
+}
+
 USpoofChecker *__hs_uspoof_openFromSource(const char *confusables, int32_t confusablesLen,
                                           const char *confusablesWholeScript, int32_t confusablesWholeScriptLen,
                                           int32_t *errType, int32_t *unused, /* really UParseError */

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -491,6 +491,16 @@ URestrictionLevel __hs_uspoof_getRestrictionLevel(const USpoofChecker *sc)
     return uspoof_getRestrictionLevel(sc);
 }
 
+void __hs_uspoof_setAllowedLocales(USpoofChecker *sc, const char *localesList, UErrorCode *status)
+{
+    uspoof_setAllowedLocales(sc, localesList, status);
+}
+
+const char *__hs_uspoof_getAllowedLocales(USpoofChecker *sc, UErrorCode *status)
+{
+    return uspoof_getAllowedLocales(sc, status);
+}
+
 int32_t __hs_uspoof_check(USpoofChecker *sc, const UChar *id,
                           int32_t length, int32_t *position,
                           UErrorCode *status)

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -508,6 +508,11 @@ int32_t __hs_uspoof_getSkeleton(USpoofChecker *sc,
     return uspoof_getSkeleton(sc, type, id, length, dest, destCapacity, status);
 }
 
+int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity, UErrorCode *status)
+{
+    return uspoof_serialize(sc, data, capacity, status);
+}
+
 void __hs_uspoof_close(USpoofChecker *sc)
 {
     uspoof_close(sc);

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -449,3 +449,56 @@ int32_t __hs_uregex_group(URegularExpression *regexp, int32_t groupNum,
 {
     return uregex_group(regexp, groupNum, dest, destCapacity, status);
 }
+
+USpoofChecker *__hs_uspoof_open(UErrorCode *status)
+{
+    return uspoof_open(status);
+}
+
+void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks, UErrorCode *status)
+{
+    uspoof_setChecks(sc, checks, status);
+}
+
+int32_t __hs_uspoof_getChecks(const USpoofChecker *sc, UErrorCode *status)
+{
+    return uspoof_getChecks(sc, status);
+}
+
+void __hs_uspoof_setRestrictionLevel(USpoofChecker *sc, URestrictionLevel level)
+{
+    uspoof_setRestrictionLevel(sc, level);
+}
+
+URestrictionLevel __hs_uspoof_getRestrictionLevel(const USpoofChecker *sc)
+{
+    return uspoof_getRestrictionLevel(sc);
+}
+
+int32_t __hs_uspoof_check(USpoofChecker *sc, const UChar *id,
+                          int32_t length, int32_t *position,
+                          UErrorCode *status)
+{
+    return uspoof_check(sc, id, length, position, status);
+}
+
+int32_t __hs_uspoof_areConfusable(USpoofChecker *sc,
+                                  const UChar *id1, int32_t length1,
+                                  const UChar *id2, int32_t length2,
+                                  UErrorCode *status)
+{
+    return uspoof_areConfusable(sc, id1, length1, id2, length2, status);
+}
+
+int32_t __hs_uspoof_getSkeleton(USpoofChecker *sc,
+                                int32_t type, const UChar *id, int32_t length,
+                                UChar *dest, int32_t destCapacity,
+                                UErrorCode *status)
+{
+    return uspoof_getSkeleton(sc, type, id, length, dest, destCapacity, status);
+}
+
+void __hs_uspoof_close(USpoofChecker *sc)
+{
+    uspoof_close(sc);
+}

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -180,6 +180,10 @@ int32_t __hs_u_strCompareIter(UCharIterator *iter1, UCharIterator *iter2);
 /* uspoof.h */
 
 USpoofChecker *__hs_uspoof_open(UErrorCode *status);
+USpoofChecker *__hs_uspoof_openFromSource(const char *confusables, int32_t confusablesLen,
+                                          const char *confusablesWholeScript, int32_t confusablesWholeScriptLen,
+                                          int32_t *errType, int32_t *unused, /* really UParseError */
+                                          UErrorCode *status);
 void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks, UErrorCode *status);
 int32_t __hs_uspoof_getChecks(const USpoofChecker *sc, UErrorCode *status);
 

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -193,6 +193,9 @@ int32_t __hs_uspoof_getChecks(const USpoofChecker *sc, UErrorCode *status);
 void __hs_uspoof_setRestrictionLevel(USpoofChecker *sc, URestrictionLevel restrictionLevel);
 URestrictionLevel __hs_uspoof_getRestrictionLevel(const USpoofChecker *sc);
 
+void __hs_uspoof_setAllowedLocales(USpoofChecker *sc, const char *localesList, UErrorCode *status);
+const char *__hs_uspoof_getAllowedLocales(USpoofChecker *sc, UErrorCode *status);
+
 int32_t __hs_uspoof_check(USpoofChecker *sc, const UChar *id,
                           int32_t length, int32_t *position,
                           UErrorCode *status);

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -188,7 +188,7 @@ USpoofChecker *__hs_uspoof_openFromSource(const char *confusables,
                                           const char *confusablesWholeScript,
                                           int32_t confusablesWholeScriptLen,
                                           int32_t *errType,
-                                          int32_t *unused, /* UParseError * */
+                                          UParseError *parseError,
                                           UErrorCode *status);
 void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks,
                            UErrorCode *status);

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -202,4 +202,5 @@ int32_t __hs_uspoof_getSkeleton(USpoofChecker *sc, int32_t checks,
                                 const UChar *id, int32_t length,
                                 UChar *dest, int32_t destCapacity,
                                 UErrorCode *status);
+int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity, UErrorCode *status);
 void __hs_uspoof_close(USpoofChecker *sc);

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -180,21 +180,29 @@ int32_t __hs_u_strCompareIter(UCharIterator *iter1, UCharIterator *iter2);
 /* uspoof.h */
 
 USpoofChecker *__hs_uspoof_open(UErrorCode *status);
-USpoofChecker *__hs_uspoof_openFromSerialized(const void *data, int32_t length, int32_t *pActualLength,
+USpoofChecker *__hs_uspoof_openFromSerialized(const void *data, int32_t length,
+                                              int32_t *pActualLength,
                                               UErrorCode *status);
-USpoofChecker *__hs_uspoof_openFromSource(const char *confusables, int32_t confusablesLen,
-                                          const char *confusablesWholeScript, int32_t confusablesWholeScriptLen,
-                                          int32_t *errType, int32_t *unused, /* really UParseError */
+USpoofChecker *__hs_uspoof_openFromSource(const char *confusables,
+                                          int32_t confusablesLen,
+                                          const char *confusablesWholeScript,
+                                          int32_t confusablesWholeScriptLen,
+                                          int32_t *errType,
+                                          int32_t *unused, /* UParseError * */
                                           UErrorCode *status);
-void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks, UErrorCode *status);
+void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks,
+                           UErrorCode *status);
 int32_t __hs_uspoof_getChecks(const USpoofChecker *sc, UErrorCode *status);
 
 // Yes, these really don't take UErrorCode *..
-void __hs_uspoof_setRestrictionLevel(USpoofChecker *sc, URestrictionLevel restrictionLevel);
+void __hs_uspoof_setRestrictionLevel(USpoofChecker *sc,
+                                     URestrictionLevel restrictionLevel);
 URestrictionLevel __hs_uspoof_getRestrictionLevel(const USpoofChecker *sc);
 
-void __hs_uspoof_setAllowedLocales(USpoofChecker *sc, const char *localesList, UErrorCode *status);
-const char *__hs_uspoof_getAllowedLocales(USpoofChecker *sc, UErrorCode *status);
+void __hs_uspoof_setAllowedLocales(USpoofChecker *sc, const char *localesList,
+                                   UErrorCode *status);
+const char *__hs_uspoof_getAllowedLocales(USpoofChecker *sc,
+                                          UErrorCode *status);
 
 int32_t __hs_uspoof_check(USpoofChecker *sc, const UChar *id,
                           int32_t length, int32_t *position,
@@ -207,5 +215,6 @@ int32_t __hs_uspoof_getSkeleton(USpoofChecker *sc, int32_t checks,
                                 const UChar *id, int32_t length,
                                 UChar *dest, int32_t destCapacity,
                                 UErrorCode *status);
-int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity, UErrorCode *status);
+int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity,
+                              UErrorCode *status);
 void __hs_uspoof_close(USpoofChecker *sc);

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -180,6 +180,8 @@ int32_t __hs_u_strCompareIter(UCharIterator *iter1, UCharIterator *iter2);
 /* uspoof.h */
 
 USpoofChecker *__hs_uspoof_open(UErrorCode *status);
+USpoofChecker *__hs_uspoof_openFromSerialized(const void *data, int32_t length, int32_t *pActualLength,
+                                              UErrorCode *status);
 USpoofChecker *__hs_uspoof_openFromSource(const char *confusables, int32_t confusablesLen,
                                           const char *confusablesWholeScript, int32_t confusablesWholeScriptLen,
                                           int32_t *errType, int32_t *unused, /* really UParseError */

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -11,6 +11,7 @@
 #include "unicode/uiter.h"
 #include "unicode/unorm.h"
 #include "unicode/uregex.h"
+#include "unicode/uspoof.h"
 #include "unicode/ustring.h"
 
 #include <stdint.h>
@@ -175,3 +176,26 @@ int32_t __hs_u_strToLower(UChar *dest, int32_t destCapacity,
 			  const UChar *src, int32_t srcLength,
 			  const char *locale, UErrorCode *pErrorCode);
 int32_t __hs_u_strCompareIter(UCharIterator *iter1, UCharIterator *iter2);
+
+/* uspoof.h */
+
+USpoofChecker *__hs_uspoof_open(UErrorCode *status);
+void __hs_uspoof_setChecks(USpoofChecker *sc, int32_t checks, UErrorCode *status);
+int32_t __hs_uspoof_getChecks(const USpoofChecker *sc, UErrorCode *status);
+
+// Yes, these really don't take UErrorCode *..
+void __hs_uspoof_setRestrictionLevel(USpoofChecker *sc, URestrictionLevel restrictionLevel);
+URestrictionLevel __hs_uspoof_getRestrictionLevel(const USpoofChecker *sc);
+
+int32_t __hs_uspoof_check(USpoofChecker *sc, const UChar *id,
+                          int32_t length, int32_t *position,
+                          UErrorCode *status);
+int32_t __hs_uspoof_areConfusable(USpoofChecker *sc,
+                                  const UChar *id1, int32_t length1,
+                                  const UChar *id2, int32_t length2,
+                                  UErrorCode *status);
+int32_t __hs_uspoof_getSkeleton(USpoofChecker *sc, int32_t checks,
+                                const UChar *id, int32_t length,
+                                UChar *dest, int32_t destCapacity,
+                                UErrorCode *status);
+void __hs_uspoof_close(USpoofChecker *sc);

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -13,7 +13,8 @@ import Data.Function (on)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.ICU (NormalizationMode(..))
-import QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..), NonSpoofableText(..))
+import QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..),
+                        NonSpoofableText(..))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import qualified Data.Text as T
@@ -81,8 +82,10 @@ t_numericValue = t_rnf $ I.numericValue
 -- Spoofing
 
 t_nonspoofable (NonSpoofableText t) = I.spoofCheck I.spoof t == I.CheckOK
-t_spoofable (LatinSpoofableText t) = I.spoofCheck I.spoof t == I.CheckFailed [I.WholeScriptConfusable]
-t_confusable (NonEmptyText t) = I.areConfusable I.spoof t t == I.CheckFailed [I.SingleScriptConfusable]
+t_spoofable (LatinSpoofableText t) = I.spoofCheck I.spoof t ==
+                                     I.CheckFailed [I.WholeScriptConfusable]
+t_confusable (NonEmptyText t) = I.areConfusable I.spoof t t ==
+                                I.CheckFailed [I.SingleScriptConfusable]
 
 tests :: Test
 tests =

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -13,7 +13,7 @@ import Data.Function (on)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.ICU (NormalizationMode(..))
-import QuickCheckUtils ()
+import QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..), NonSpoofableText(..))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import qualified Data.Text as T
@@ -78,6 +78,11 @@ t_mirror = t_rnf $ I.mirror
 t_digitToInt = t_rnf $ I.digitToInt
 t_numericValue = t_rnf $ I.numericValue
 
+-- Spoofing
+
+t_nonspoofable (NonSpoofableText t) = I.spoofCheck I.spoof t == I.CheckOK
+t_spoofable (LatinSpoofableText t) = I.spoofCheck I.spoof t == I.CheckFailed [I.WholeScriptConfusable]
+t_confusable (NonEmptyText t) = I.areConfusable I.spoof t t == I.CheckFailed [I.SingleScriptConfusable]
 
 tests :: Test
 tests =
@@ -101,4 +106,7 @@ tests =
   , testProperty "t_mirror" t_mirror
   , testProperty "t_digitToInt" t_digitToInt
   , testProperty "t_numericValue" t_numericValue
+  , testProperty "t_spoofable" t_spoofable
+  , testProperty "t_nonspoofable" t_nonspoofable
+  , testProperty "t_confusable" t_confusable
   ]

--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..), NonSpoofableText(..)) where
+module QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..),
+                        NonSpoofableText(..)) where
 
 import Control.Applicative ((<$>))
 import Control.DeepSeq (NFData(..))
@@ -31,9 +32,11 @@ newtype NonEmptyText = NonEmptyText { nonEmptyText :: T.Text } deriving Show
 instance Arbitrary NonEmptyText where
   arbitrary = NonEmptyText <$> T.pack <$> listOf1 arbitrary
 
-newtype LatinSpoofableText = LatinSpoofableText { latinSpoofableText :: T.Text } deriving Show
+newtype LatinSpoofableText = LatinSpoofableText { latinSpoofableText :: T.Text }
+                           deriving Show
 instance Arbitrary LatinSpoofableText where
-    arbitrary = LatinSpoofableText <$> T.pack <$> listOf1 genCyrillicLatinSpoofableChar
+    arbitrary = LatinSpoofableText <$> T.pack <$>
+                listOf1 genCyrillicLatinSpoofableChar
 
 genCyrillicLatinSpoofableChar :: Gen Char
 genCyrillicLatinSpoofableChar = elements (
@@ -42,11 +45,13 @@ genCyrillicLatinSpoofableChar = elements (
   ['\x0445'..'\x0446'] ++
   "\x044A" ++
   ['\x0454'..'\x0456'] ++
-  "\x0458\x045B\x048D\x0491\x0493\x049B\x049F\x04AB\x04AD\x04AF\x04B1\x04BB\x04BD\x04BF" ++
+  "\x0458\x045B\x048D\x0491\x0493\x049B\x049F\x04AB\x04AD\x04AF\x04B1\x04BB\
+  \\x04BD\x04BF" ++
   ['\x04CE'..'\x04CF'] ++
   "\x04D5\x04D9\x04E9\x0501\x0511\x051B\x051D")
 
-newtype NonSpoofableText = NonSpoofableText { nonSpoofableText :: T.Text } deriving Show
+newtype NonSpoofableText = NonSpoofableText { nonSpoofableText :: T.Text }
+                         deriving Show
 
 instance Arbitrary NonSpoofableText where
     arbitrary = NonSpoofableText <$> T.pack <$> listOf1 genNonSpoofableChar

--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module QuickCheckUtils () where
+module QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..), NonSpoofableText(..)) where
 
 import Control.Applicative ((<$>))
 import Control.DeepSeq (NFData(..))
 import Data.Text.ICU (Collator, LocaleName(..), NormalizationMode(..))
 import Data.Text.ICU.Break (available)
-import Test.QuickCheck (Arbitrary(..), elements)
+import Test.QuickCheck (Arbitrary(..), Gen, elements, listOf1)
 import qualified Data.Text as T
 import qualified Data.Text.ICU as I
 
@@ -26,3 +26,30 @@ instance Arbitrary NormalizationMode where
 
 instance Arbitrary Collator where
     arbitrary = I.collator <$> arbitrary
+
+newtype NonEmptyText = NonEmptyText { nonEmptyText :: T.Text } deriving Show
+instance Arbitrary NonEmptyText where
+  arbitrary = NonEmptyText <$> T.pack <$> listOf1 arbitrary
+
+newtype LatinSpoofableText = LatinSpoofableText { latinSpoofableText :: T.Text } deriving Show
+instance Arbitrary LatinSpoofableText where
+    arbitrary = LatinSpoofableText <$> T.pack <$> listOf1 genCyrillicLatinSpoofableChar
+
+genCyrillicLatinSpoofableChar :: Gen Char
+genCyrillicLatinSpoofableChar = elements (
+  "\x043A\x043E\x0433\x0435\x043A\x043C" ++
+  ['\x043E'..'\x0443'] ++
+  ['\x0445'..'\x0446'] ++
+  "\x044A" ++
+  ['\x0454'..'\x0456'] ++
+  "\x0458\x045B\x048D\x0491\x0493\x049B\x049F\x04AB\x04AD\x04AF\x04B1\x04BB\x04BD\x04BF" ++
+  ['\x04CE'..'\x04CF'] ++
+  "\x04D5\x04D9\x04E9\x0501\x0511\x051B\x051D")
+
+newtype NonSpoofableText = NonSpoofableText { nonSpoofableText :: T.Text } deriving Show
+
+instance Arbitrary NonSpoofableText where
+    arbitrary = NonSpoofableText <$> T.pack <$> listOf1 genNonSpoofableChar
+
+genNonSpoofableChar :: Gen Char
+genNonSpoofableChar = elements "QDFRz"

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -59,8 +59,10 @@ library
       Data.Text.ICU.Error
       Data.Text.ICU.Normalize
       Data.Text.ICU.Regex
+      Data.Text.ICU.Spoof
       Data.Text.ICU.Types
   other-modules:
+      Data.Text.ICU.BitMask
       Data.Text.ICU.Break.Pure
       Data.Text.ICU.Break.Types
       Data.Text.ICU.Collate.Internal
@@ -72,6 +74,8 @@ library
       Data.Text.ICU.Normalize.Internal
       Data.Text.ICU.Regex.Internal
       Data.Text.ICU.Regex.Pure
+      Data.Text.ICU.Spoof.Internal
+      Data.Text.ICU.Spoof.Pure
       Data.Text.ICU.Text
   c-sources: cbits/text_icu.c
   include-dirs: include

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -29,6 +29,8 @@ description:
     unique binary representation.)
   .
   * Regular expression search and replace.
+  .
+  * Security checks for visually confusable (spoofable) strings.
 maintainer:     Bryan O'Sullivan <bos@serpentine.com>
 copyright:      2009-2014 Bryan O'Sullivan
 category:       Data, Text


### PR DESCRIPTION
This is my first attempt at integrating ICU's Unicode spoof-checking library with `Data.Text.ICU`.

This library checks for nasty Unicode lookalikes:

```
λ import Data.Text
λ import Data.Text.ICU
λ areConfusable spoof (pack "Hello") (pack "World")
CheckOK
λ let cyrillic = "\x0410\x0412\x0421\x0415"
λ :print cyrillic
cyrillic = "АВСЕ"
λ areConfusable spoof (pack "ABCE") (pack cyrillic)
CheckFailed [MixedScriptConfusable,WholeScriptConfusable]
```

More tests are better, but this is a nice start.

C library: http://icu-project.org/apiref/icu4c/uspoof_8h.html

