### PR TITLE
Added paths for OS X Homebrew installation of `icu`

### DIFF
--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -81,6 +81,9 @@ library
       Data.Text.ICU.Text
   c-sources: cbits/text_icu.c
   include-dirs: include
+  if os(darwin)
+    extra-lib-dirs: /usr/local/opt/icu4c/lib
+    include-dirs: /usr/local/opt/icu4c/include
   extra-libraries: icuuc
   if os(mingw32)
     extra-libraries: icuin icudt


### PR DESCRIPTION
Basically because of http://stackoverflow.com/questions/7420514/using-text-icu-library-in-haskell-on-mac-os
